### PR TITLE
Emit warning object as error is not defined in the scope

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ var compile = function compile(options) {
 
       if (stats.hasWarnings()) {
         stats.compilation.warnings.forEach(function (warning) {
-          _this.emit('warning', error);
+          _this.emit('warning', warning);
         });
       }
 


### PR DESCRIPTION
..otherwise you get this sort of thing:

```
/path/to/your/project/node_modules/gulp-webpack-sourcemaps/lib/index.js:94
          _this.emit('warning', error);
                                ^

ReferenceError: error is not defined
```
