### PR TITLE
Fix ReferenceError

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ const compile = (options) => {
 
       if (stats.hasWarnings()) {
         stats.compilation.warnings.forEach(warning => {
-          this.emit('warning', error);
+          this.emit('warning', warning);
         });
       }
 


### PR DESCRIPTION
Otherwise you get this sort of thing:

```console
/path/to/my/module/node_modules/gulp-webpack-sourcemaps/lib/index.js:94
          _this.emit('warning', error);
                                ^

ReferenceError: error is not defined
    at /path/to/my/module/node_modules/gulp-webpack-sourcemaps/lib/index.js:94:33
    at Array.forEach (<anonymous>)
    at done (/path/to/my/module/node_modules/gulp-webpack-sourcemaps/lib/index.js:93:36)
    at Compiler.<anonymous> (/path/to/my/module/node_modules/webpack/lib/Compiler.js:194:14)
    at Compiler.emitRecords (/path/to/my/module/node_modules/webpack/lib/Compiler.js:282:37)
    at Compiler.<anonymous> (/path/to/my/module/node_modules/webpack/lib/Compiler.js:187:11)
    at /path/to/my/module/node_modules/webpack/lib/Compiler.js:275:11
    at Compiler.applyPluginsAsync (/path/to/my/module/node_modules/tapable/lib/Tapable.js:60:69)
    at Compiler.afterEmit (/path/to/my/module/node_modules/webpack/lib/Compiler.js:272:8)
    at Compiler.<anonymous> (/path/to/my/module/node_modules/webpack/lib/Compiler.js:267:14)
```